### PR TITLE
fix double click

### DIFF
--- a/cd_fif4.py
+++ b/cd_fif4.py
@@ -2456,6 +2456,7 @@ class Fif4D:
             if not m.reporter:      return []
             if not m.srcf.fif_path: return []
             pass;              #log("m.srcf.fif_path={}",(m.srcf.fif_path))
+            m.rslt_srcf_acts('on_rslt_crt') # trigger on_caret event of 'results' view, 'source' view will be updated
             tab_ed  = None
             path    = m.srcf.fif_path
             if path.startswith('tab:'):


### PR DESCRIPTION
fixed the situation when double-clicking on result in `result view` will not take you to correct file/line because `source view` is not updated on dbl-click.